### PR TITLE
Fixed the CPU::reset function

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -65,9 +65,8 @@ impl CPU {
     }
 
     pub fn reset(&mut self) {
-        self.ip = 0;
-        self.instruction_count = 0;
-        // XXX clear memory
+        let cpu = CPU::new();
+        *self = cpu;
     }
 
     pub fn load_bios(&mut self, data: &[u8]) {


### PR DESCRIPTION
This is a very naive implementation, but it works.

I'm trying to debug the memory corruption bug, but it's annoying that I can't reset the CPU, so here is a quick fix for the reset function